### PR TITLE
feat: add Tailscale TSIDP identity provider

### DIFF
--- a/apps/tsidp.yml
+++ b/apps/tsidp.yml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/argoproj.io/application_v1alpha1.json
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tsidp
+spec:
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: tsidp
+
+  sources:
+    - path: tsidp/templates
+      repoURL: 'https://github.com/dkarter/k3s-cluster-apps.git'
+      targetRevision: HEAD
+
+    - repoURL: 'https://github.com/dkarter/k3s-cluster-apps.git'
+      targetRevision: HEAD
+      ref: values
+
+    - chart: app-template
+      repoURL: https://bjw-s-labs.github.io/helm-charts
+      targetRevision: 4.4.0
+      helm:
+        releaseName: tsidp
+        valueFiles:
+          - $values/tsidp/values.yml
+
+  project: default
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/tsidp/templates/tsidp-env-external-secret.yml
+++ b/tsidp/templates/tsidp-env-external-secret.yml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: tsidp-env
+  namespace: tsidp
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: onepassword-connect
+    kind: ClusterSecretStore
+  target:
+    name: tsidp-env
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      mergePolicy: Replace
+      data:
+        TS_AUTHKEY: '{{ .TS_AUTHKEY }}'
+  dataFrom:
+    - extract:
+        key: tsidp
+        metadataPolicy: None
+        decodingStrategy: None
+        conversionStrategy: Default

--- a/tsidp/templates/tsidp-env-external-secret.yml
+++ b/tsidp/templates/tsidp-env-external-secret.yml
@@ -16,7 +16,7 @@ spec:
       engineVersion: v2
       mergePolicy: Replace
       data:
-        TS_AUTHKEY: '{{ .TS_AUTHKEY }}'
+        TS_AUTHKEY: '{{ .client_secret }}'
   dataFrom:
     - extract:
         key: tsidp

--- a/tsidp/values.yml
+++ b/tsidp/values.yml
@@ -9,7 +9,7 @@ controllers:
       app:
         image:
           repository: ghcr.io/tailscale/tsidp
-          tag: v1.96.4
+          tag: v0.0.12
           pullPolicy: IfNotPresent
 
         env:

--- a/tsidp/values.yml
+++ b/tsidp/values.yml
@@ -9,7 +9,7 @@ controllers:
       app:
         image:
           repository: ghcr.io/tailscale/tsidp
-          tag: latest
+          tag: v1.96.4
           pullPolicy: IfNotPresent
 
         env:

--- a/tsidp/values.yml
+++ b/tsidp/values.yml
@@ -1,0 +1,43 @@
+app_port: &app_port 443
+
+controllers:
+  main:
+    strategy: Recreate
+    replicas: 1
+
+    containers:
+      app:
+        image:
+          repository: ghcr.io/tailscale/tsidp
+          tag: latest
+          pullPolicy: IfNotPresent
+
+        env:
+          TS_AUTHKEY:
+            valueFrom:
+              secretKeyRef:
+                name: tsidp-env
+                key: TS_AUTHKEY
+
+        probes:
+          liveness:
+            enabled: false
+          readiness:
+            enabled: false
+
+persistence:
+  state:
+    enabled: true
+    type: persistentVolumeClaim
+    accessMode: ReadWriteOnce
+    size: 1Gi
+    globalMounts:
+      - path: /root/.local/share/tsnet-tsidp
+
+service:
+  app:
+    controller: main
+    ports:
+      https:
+        port: *app_port
+        protocol: HTTPS

--- a/tsidp/values.yml
+++ b/tsidp/values.yml
@@ -13,6 +13,8 @@ controllers:
           pullPolicy: IfNotPresent
 
         env:
+          TAILSCALE_USE_WIP_CODE: '1'
+          TS_ADVERTISE_TAGS: 'tag:tsidp'
           TS_AUTHKEY:
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
## Summary

- Deploys `ghcr.io/tailscale/tsidp` as a self-hosted OIDC identity provider backed by the Tailscale network
- Adds ExternalSecret pulling `TS_AUTHKEY` from 1Password (key: `tsidp`)
- Persistent 1Gi volume for tsnet state at `/root/.local/share/tsnet-tsidp`

## Test plan

- [ ] Add a `tsidp` item to 1Password vault `K3s.Pro` with a `TS_AUTHKEY` field containing a Tailscale auth key (reusable, tagged for tsidp)
- [ ] Verify ArgoCD syncs the `tsidp` application and namespace is created
- [ ] Confirm the pod starts and joins the tailnet (check pod logs)
- [ ] Verify the OIDC discovery endpoint is reachable at `https://tsidp.<tailnet>.ts.net/.well-known/openid-configuration`

https://claude.ai/code/session_01P13Q88HGSUecq9AYY9PjKA