### PR TITLE
fix: correct tsidp startup configuration

### DIFF
--- a/tsidp/values.yml
+++ b/tsidp/values.yml
@@ -12,9 +12,11 @@ controllers:
           tag: v0.0.12
           pullPolicy: IfNotPresent
 
+        args:
+          - --advertise-tags=tag:tsidp
+
         env:
           TAILSCALE_USE_WIP_CODE: '1'
-          TS_ADVERTISE_TAGS: 'tag:tsidp'
           TS_AUTHKEY:
             valueFrom:
               secretKeyRef:
@@ -34,7 +36,7 @@ persistence:
     accessMode: ReadWriteOnce
     size: 1Gi
     globalMounts:
-      - path: /root/.local/share/tsnet-tsidp
+      - path: /home/app/.config/tsnet-tsidp-server
 
 service:
   app:


### PR DESCRIPTION
## Summary

Fixes tsidp failing to start after initial deployment.

- **Wrong state path**: container runs as `app` user, so tsnet state lives at `/home/app/.config/tsnet-tsidp-server` — not `/root/.local/share/tsnet-tsidp`
- **`TS_ADVERTISE_TAGS` not honoured**: tsidp/tsnet requires advertise tags as a CLI flag (`--advertise-tags=tag:tsidp`), not an env var

## Error fixed

```
ERROR failed to start tsnet server error="tsnet.Up: tsnet: error resolving auth key: oauth authkeys require --advertise-tags"
```

https://claude.ai/code/session_01P13Q88HGSUecq9AYY9PjKA

---
_Generated by [Claude Code](https://claude.ai/code/session_01P13Q88HGSUecq9AYY9PjKA)_