### PR TITLE
fix: switch tsidp to regular auth key, fix state dir and args

### DIFF
--- a/tsidp/templates/tsidp-env-external-secret.yml
+++ b/tsidp/templates/tsidp-env-external-secret.yml
@@ -16,7 +16,7 @@ spec:
       engineVersion: v2
       mergePolicy: Replace
       data:
-        TS_AUTHKEY: '{{ .client_secret }}'
+        TS_AUTHKEY: '{{ .TS_AUTHKEY }}'
   dataFrom:
     - extract:
         key: tsidp

--- a/tsidp/values.yml
+++ b/tsidp/values.yml
@@ -13,7 +13,7 @@ controllers:
           pullPolicy: IfNotPresent
 
         args:
-          - --advertise-tags=tag:tsidp
+          - -dir=/data
 
         env:
           TAILSCALE_USE_WIP_CODE: '1'
@@ -36,7 +36,7 @@ persistence:
     accessMode: ReadWriteOnce
     size: 1Gi
     globalMounts:
-      - path: /home/app/.config/tsnet-tsidp-server
+      - path: /data
 
 service:
   app:


### PR DESCRIPTION
## Summary

- **Switch to regular auth key**: v0.0.12 has no `-advertise-tags` flag and tsnet has no `TS_ADVERTISE_TAGS` env var, so OAuth client secrets can't work with this version. Use a regular reusable auth key instead (no advertise-tags required).
- **Fix state directory**: use `-dir=/data` flag (verified valid in v0.0.12) and mount PVC at `/data`
- **Update ExternalSecret**: read `TS_AUTHKEY` field from 1Password `tsidp` item instead of `client_secret`

## Action required

In 1Password (`tsidp` item): add a `TS_AUTHKEY` field with a reusable auth key from https://login.tailscale.com/admin/settings/keys

https://claude.ai/code/session_01P13Q88HGSUecq9AYY9PjKA

---
_Generated by [Claude Code](https://claude.ai/code/session_01P13Q88HGSUecq9AYY9PjKA)_