### PR TITLE
Fix empty GitHub base ref handling

### DIFF
--- a/test/validator_checks_test.exs
+++ b/test/validator_checks_test.exs
@@ -71,7 +71,7 @@ defmodule ValidatorChecksTest do
       git!(repo, ["add", "."])
       git!(repo, ["commit", "-m", "update chart"])
 
-      {output, status} = run_script(repo, @values_script, [])
+      {output, status} = run_script(repo, @values_script, env: [{"GITHUB_BASE_REF", ""}])
 
       assert status == 1
       assert output =~ "apps/demo/values.yml: app-template annotation is 4.6.2, chart is 4.7.0"
@@ -197,7 +197,9 @@ defmodule ValidatorChecksTest do
   end
 
   defp run_script(repo, script, opts) do
-    env = if base_ref = opts[:base_ref], do: [{"BASE_REF", base_ref}], else: []
+    env = opts[:env] || []
+
+    env = if base_ref = opts[:base_ref], do: [{"BASE_REF", base_ref} | env], else: env
 
     env =
       if bin_path = opts[:bin_path],

--- a/validator_utils.exs
+++ b/validator_utils.exs
@@ -2,8 +2,8 @@ defmodule ValidatorUtils do
   @moduledoc false
 
   def base_ref do
-    System.get_env("BASE_REF") ||
-      System.get_env("GITHUB_BASE_REF") ||
+    env_ref("BASE_REF") ||
+      env_ref("GITHUB_BASE_REF") ||
       default_base_ref()
   end
 
@@ -55,6 +55,13 @@ defmodule ValidatorUtils do
   end
 
   def cmd(command, args), do: System.cmd(command, args, stderr_to_stdout: true)
+
+  defp env_ref(name) do
+    case System.get_env(name) do
+      nil -> nil
+      value -> if String.trim(value) == "", do: nil, else: value
+    end
+  end
 
   defp default_base_ref do
     case current_branch() do


### PR DESCRIPTION
## Summary
- Ignore blank `BASE_REF` and `GITHUB_BASE_REF` values when choosing the validator base ref.
- Update validator tests to cover an empty GitHub base ref.