### PR TITLE
fix: align external secrets with chart defaults

### DIFF
--- a/argo-cd/templates/argocd-notifications-external-secret.yml
+++ b/argo-cd/templates/argocd-notifications-external-secret.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -12,6 +12,7 @@ spec:
   target:
     name: argocd-notifications-secret
     creationPolicy: Owner
+    deletionPolicy: Retain
     template:
       engineVersion: v2
       mergePolicy: Replace
@@ -23,3 +24,4 @@ spec:
         metadataPolicy: None
         decodingStrategy: None
         conversionStrategy: Default
+        nullBytePolicy: Ignore

--- a/external-secrets/op-connect-access-token-external-secret.yml
+++ b/external-secrets/op-connect-access-token-external-secret.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -12,6 +12,7 @@ spec:
   target:
     name: op-connect-access-token
     creationPolicy: Owner
+    deletionPolicy: Retain
     template:
       engineVersion: v2
       mergePolicy: Replace
@@ -24,3 +25,4 @@ spec:
         metadataPolicy: None
         decodingStrategy: None
         conversionStrategy: Default
+        nullBytePolicy: Ignore

--- a/monitoring/templates/grafana-postgresql-external-secret.yml
+++ b/monitoring/templates/grafana-postgresql-external-secret.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -12,6 +12,7 @@ spec:
   target:
     name: grafana-postgresql-credentials
     creationPolicy: Owner
+    deletionPolicy: Retain
     template:
       engineVersion: v2
       mergePolicy: Replace
@@ -23,3 +24,4 @@ spec:
         metadataPolicy: None
         decodingStrategy: None
         conversionStrategy: Default
+        nullBytePolicy: Ignore

--- a/monitoring/templates/monitoring-grafana-admin-external-secret.yml
+++ b/monitoring/templates/monitoring-grafana-admin-external-secret.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -12,6 +12,7 @@ spec:
   target:
     name: grafana-admin
     creationPolicy: Owner
+    deletionPolicy: Retain
     template:
       engineVersion: v2
       mergePolicy: Replace
@@ -24,3 +25,4 @@ spec:
         metadataPolicy: None
         decodingStrategy: None
         conversionStrategy: Default
+        nullBytePolicy: Ignore


### PR DESCRIPTION
# Motivation

External Secrets v2.4.0 now defaults fields that were absent from a few Git-managed ExternalSecret manifests. ArgoCD kept reporting those resources as OutOfSync even though the generated secrets were healthy.

# Summary of Changes

- Add explicit `deletionPolicy: Retain` to affected ExternalSecret targets.
- Add explicit `nullBytePolicy: Ignore` to affected `dataFrom.extract` blocks.
- Update the ExternalSecret YAML schema annotation to a schema that includes the v2.4.0 fields.

# Testing

- Ran `task validate` successfully.
- Push hooks passed formatting, schema drift checks, and YAML validation.

# Dependencies/Special Considerations

The ArgoCD web login issue was caused by clock skew on `k3s6`; this PR only addresses the ExternalSecret OutOfSync drift.