### PR TITLE
fix(ci): pin check-jsonschema to 0.37.1 to fix mise 2026.6.11 install bug

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -5,7 +5,7 @@ erlang = "28"
 helm = "latest"
 jq = "latest"
 lefthook = { version = "latest" }
-"pipx:check-jsonschema" = "latest"
+"pipx:check-jsonschema" = "0.37.1"
 task = "latest"
 "github:crate-ci/committed" = "latest"
 aube = "latest"


### PR DESCRIPTION
## Summary

- Pins `pipx:check-jsonschema` to `0.37.1` in `mise.toml` instead of `"latest"`

## Problem

mise 2026.6.11 introduced a bug where it uses `pip install --uploaded-prior-to=<timestamp>` when resolving `"latest"` versions for pipx tools. This flag is not supported by the pip version in CI runners, causing ALL 4 CI jobs to fail at the `mise install` step with:

```
mise ERROR Failed to install pipx:check-jsonschema@latest: pipx exited with non-zero status: exit code 1
no such option: --uploaded-prior-to
```

This broke CI for all open Renovate PRs (#537, #538).

## Fix

Pin `check-jsonschema` to `0.37.1` (the previously working version). With a pinned version, mise uses a direct `pip install check-jsonschema==0.37.1` without the timestamp flag, bypassing the bug.

https://claude.ai/code/session_01XQ1txfitpVWKD6XEF9QfAZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQ1txfitpVWKD6XEF9QfAZ)_